### PR TITLE
Refactor category page to use category slug insted of category Id

### DIFF
--- a/src/components/products/components/ProductCard.jsx
+++ b/src/components/products/components/ProductCard.jsx
@@ -21,7 +21,7 @@ const ProductCard = ({ product }) => {
           <CardMedia
             draggable="false"
             component="img"
-            image={image ?? '/public/images/img-placeholder.png'}
+            image={imgPath ?? '/public/images/img-placeholder.png'}
             sx={{
               borderRadius: 2,
               height: 285,

--- a/src/components/products/components/ProductGrid.jsx
+++ b/src/components/products/components/ProductGrid.jsx
@@ -15,7 +15,7 @@ const ProductGrid = ({ products }) => {
     >
       {products &&
         products.map((product) => {
-          return <ProductCard key={product.productID} {...product} />;
+          return <ProductCard key={product.productID} product={product} />;
         })}
     </List>
   );

--- a/src/components/products/services/ProductsService.js
+++ b/src/components/products/services/ProductsService.js
@@ -5,8 +5,8 @@ export const fetchProducts = (pageSize = 9, page = 1) => {
     return fetchPath(`${environment.baseUrl}/products/search?limit=${pageSize}&page=${page}`);
 };
 
-export const fetchProductsByCategoryId = (categoryId, page = 1, pageSize = 9) => {
-    return fetchPath(`${environment.baseUrl}/products/category/${categoryId}?page=${page}&limit=${pageSize}`);
+export const fetchProductsByCategorySlug = (slug, page = 1, pageSize = 9) => {
+    return fetchPath(`${environment.baseUrl}/products/category/${slug}?page=${page}&limit=${pageSize}`);
 };
 
 

--- a/src/pages/Category/Category.jsx
+++ b/src/pages/Category/Category.jsx
@@ -1,31 +1,32 @@
 import { useEffect } from "react";
 import { useState } from "react";
-import { fetchProductsByCategoryId } from "../../components/products/services/ProductsService";
+import { fetchProductsByCategorySlug } from "../../components/products/services/ProductsService";
 import { Container, Box } from "@mui/material";
 import ProductGrid from "../../components/products/components/ProductGrid";
 import AppPagination from "../../components/shared/AppPagination/AppPagination"
 import { useParams } from "react-router-dom";
 import LoadingIndicator from "../../components/shared/LoadingIndicator/LoadingIndicator";
 import { Grid } from "@mui/material";
+import { capitalizeSlug } from "../../utilities/helpers";
 
 const Category = () => {
 
-    const { categoryId } = useParams();
+    const { slug } = useParams();
     const [loading, setLoading] = useState(false);
     const [productsResult, setProductsResult] = useState([]);
     const [currentPage, setCurrentPage] = useState(1);
-    const [pageSize, setPageSize] = useState(3);
+    const [pageSize, setPageSize] = useState(9);
 
 
     useEffect(() => {
         setLoading(true);
-        fetchProductsByCategoryId(categoryId, currentPage, pageSize)
+        fetchProductsByCategorySlug(slug, currentPage, pageSize)
             .then(data => {
                 setLoading(false);
                 setProductsResult(data);
             })
             .catch(error => console.error('Failed to load products:', error));
-    }, [currentPage]);
+    }, [currentPage, slug]);
 
     return (
         <>
@@ -35,7 +36,7 @@ const Category = () => {
                     <Grid container spacing={2}>
                         <Grid item xs={2}>
                             <p>Home  &gt; Handbag</p>
-                            <h2>Category Name</h2>
+                            <h2>{capitalizeSlug(slug)}</h2>
                         </Grid>
 
                         <Grid item xs={10}>

--- a/src/utilities/helpers.js
+++ b/src/utilities/helpers.js
@@ -1,0 +1,4 @@
+export const capitalizeSlug = (slug) => {
+    const words = slug.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1));
+    return words.join(' ');
+}


### PR DESCRIPTION
changed the method in product service to get products by slug instead of categoryId / some other refactors check the files changes 

![image](https://github.com/SD-0224/frontend-final-2/assets/41591681/2d3eedcb-0101-4a16-8ba4-6505a70f40bd)
